### PR TITLE
Niklas map cleanup

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -57,13 +57,7 @@ export const events = {
             .flat());
         
         filteredBarIds.forEach(id => {
-            const len = map.locations._markerPool.length;
-            for (let i = 0; i < len; i++) {
-                const m = map.locations._markerPool[i];
-                if (m.locationId === id) {
-                    map._layers.locations.addLayer(m);
-                }
-            }
+            map._layers.locations.addLayer(map.locations._markerPool[id])
         });
     },
 }

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -5,182 +5,138 @@ import { ui } from "./ui.js";
 import { polyline } from "./polyline.js";
 
 export const map = {
-    user: {
-        position: null,
-        marker: null,
-    },
+    /**
+     * Leaflet map object's instance.
+     */
+    _instance: null,
 
-    instance: null,
-
-    layers: {
+    /**
+     * Layer groups. When something is added/removed
+     * from the map, it's primarily done with these
+     * groups, and not directly from the map instance.
+     */
+    _layers: {
         routes: new L.FeatureGroup(),
-        locations: new L.FeatureGroup()
+        locations: new L.FeatureGroup(),
+        user: new L.FeatureGroup()
     },
 
+    /**
+     * Position object factory function.
+     * @param {number} latitude
+     * @param {number} longitude
+     */
     newPos: function (latitude, longitude) {
         return {lat: latitude, lon: longitude}
     },
 
-    moveViewOptions: {
-        animate: true,
-        duration: 0.6,
-        easeLinearity: 0.25,
-        noMoveStart: true
-    },
-
-    markerOptions: {
-        default: {
-            title : 'title here',
-            alt: 'alt comes here',
-            opacity: 0.8,
-            riseOnHover: true
-        },
-        bar: {
-            icon : L.icon({
-                iconUrl: './icons/beer-icon.png',
-                iconSize: [40, 45],
-                iconAnchor: [20, 40],
-                popupAnchor:[0, -40]
-            }),
-            title : 'Kalja rafla',
-            alt: 'alt comes here',
-            opacity: 0.8,
-            riseOnHover: true
-        },
-        pizza: {
-            icon : L.icon({
-                iconUrl: './icons/pizza-icon.png',
-                iconSize: [40, 45],
-                iconAnchor: [20, 40],
-                popupAnchor: [0, -40]
-            }),
-            title : 'pizzeria',
-            alt: 'alt comes here',
-            opacity: 0.8,
-            riseOnHover: true
-        },
-        user: {
-            title : 'Sinä',
-            alt: 'alt comes here',
-            riseOnHover: true
-        }
-    },
-
-    /**
-     * Map polyline style options. Use these
-     * when you wish to draw new polylines with
-     * pre-defined styles to map. DON'T CHANGE STATES!
-     */
-    routeDrawOptions: {
-        'DEFAULT': {
-            color: '#5eb5a7',
-            smoothFactor: 1,
-            noClip: false,
-            weight: 3,
-        },
-        'BUS': {
-            color: '#1c8bc9',
-            noClip: true,
-            weight: 3
-        },
-        'RAIL': {
-            color: '#b8659d',
-            noClip: true,
-            weight: 3
-        },
-        'SUBWAY': {
-            color: '#f75701',
-            noClip: true,
-            weight: 3
-        },
-        'TRAM': {
-            color: '#196343',
-            noClip: true,
-            weight: 3,
-        },
-        'WALK': {
-            color: '#5eb5a7',
-            noClip: true,
-            weight: 5,
-            dashArray: '1, 6',
-        },
-        'FERRY': {
-            color: '#196343',
-            noClip: true,
-            weight: 4,
-        }
-    },
-
     /**
      * Creates leaflet.js map to specified DOM element id.
-     * Map uses HSL map tiles. Created map is stored to this
-     * module. If you create new one, the old map is replaced.
+     * Map uses HSL map tiles. Created map object is stored.
+     * All map manipulation should be done using defined functions!
      * 
-     * Use the functions in this module to manipulate map state!
-     * 
-     * @param {string} mapId element id of the element where the map will be located.
+     * @param {string} elemId element id of the element where the map will be located.
      */
-    create: function (mapId) {
-        this.instance = L.map(mapId).fitWorld();
-        L.tileLayer('https://cdn.digitransit.fi/map/v1/hsl-map/{z}/{x}/{y}.png', {
-            maxZoom: 17,
-            minZoom: 11,
-            tileSize: 512,
-            zoomOffset: -1,
-            zoomControl: false
-        }).addTo(this.instance);
-
-        this.instance.locate({watch: true, timeout: 5000, setView: false});
-        this.instance.addLayer(this.layers.locations);
-        this.instance.addLayer(this.layers.routes);
-        return this;
-    },
-
-    createLocations: function(locations, options, popupHTML) {
-        const drawOptions = options ? options : this.markerOptions.default;
-
-        let barOptions = {...drawOptions};
-        locations.forEach(loc => {
-
-            barOptions.title = loc.name.fi;
-            barOptions._description = loc.description;
-            barOptions._infoUrl = loc.info_url;
-
-            const marker = L.marker([loc.location.lat, loc.location.lon], barOptions)
-                .addTo(this.instance);
-
-            if (popupHTML) {
-                marker.bindPopup(popupHTML);
+    create: function (elemId) {
+        this._instance = L.map(elemId).fitWorld();
+        L.tileLayer(
+            'https://cdn.digitransit.fi/map/v1/hsl-map/{z}/{x}/{y}.png',
+            {
+                maxZoom: 18,
+                minZoom: 11,
+                tileSize: 512,
+                zoomOffset: -1,
+                zoomControl: false
             }
+        ).addTo(this._instance);
 
-            marker.locationId = loc.id;
-
-            marker.on('click', _ => setMarkerZoom(marker))
-
-            marker.on('click', async _ => {
-                this.clearRoutes();
-                ui.toggleLocationPanel('down');
-
-                const routes = await routesAPI.getRoutesToBarAsync(this.user.position, loc.location);
-                if (routes) {
-                    ui.renderBarInfo(marker.options, routes, loc);
-                } else {
-                    ui.renderError('no routes');
-                }
-            })
-            this.locations.markerPool.push(marker);
-        });
+        this._instance.locate({watch: true, timeout: 5000, setView: false})
+            .addLayer(this._layers.locations)
+            .addLayer(this._layers.routes)
+            .addLayer(this._layers.user);
     },
 
-    focus: function() {
-        this.instance.setView([
-            this.user.position.lat, this.user.position.lon
-        ], 13);
+    gps: {
+        /**
+         * Set gps related events.
+         * @param {string} event event name
+         * @param {Function} callback function
+         */
+        on: function(event, callback) {
+            switch (event) {
+                case 'found':
+                    map._instance.on('locationfound', callback);
+                    return;
+                case 'error':
+                    map._instance.on('locationerror', callback);
+                    return;
+                default:
+                    throw new Error('Event not found');
+            }
+        }
+    },
+    
+
+    /**
+     * Namespace for manipulating user's state
+     * on the map.
+     */
+    user: {
+        /**
+         * User's current known position
+         * with latitude and longitude fields.
+         */
+        position: null,
+
+        marker: {
+
+            /**
+             * User's leaflet map marker object instance.
+             */
+            _instance: null,
+
+            /**
+             * Constructor function for user's location marker.
+             * Created object instance is added to map's user layer
+             * and stored in "instance" field.
+             */
+            create: function() {
+                const m = L.marker(map.user.position, map.options.markers.user)
+                map._layers.user.addLayer(m);
+                this._instance = m;
+            },
+
+            /**
+             * Removes user's location marker temporarily
+             * from the map. Object instance is not lost.
+             */
+            hide: function() {
+                map._layers.user.clearLayers();
+            },
+
+            /**
+             * Adds user's location marker back to map.
+             */
+            visible: function() {
+                if (this_instance) {
+                    map._layers.user.addLayer(this._instance);
+                }
+            },
+
+            /**
+             * Changes user's location marker's coordinates.
+             * @param {object} newLoc new coordinate object
+             */
+            move(newLoc) {
+                if (map.user.marker._instance) {
+                    map.user.marker._instance.setLatLng(newLoc);
+                }
+            }
+        }
     },
 
     /**
-     * Location object to house functions and data
-     * related to locations on the map.
+     * Namespace to manipulate location markers in the map.
      */
     locations: {
         /**
@@ -188,24 +144,65 @@ export const map = {
          * objects. When the objects are first
          * created, they are to be stored here.
          */
-        markerPool: [],
+        _markerPool: [],
 
         /**
-         * Cache for temporarely cleared locations
+         * Cache for temporarely cleared locations.
          */
-        cache: [],
+        _cache: [],
 
         /**
          * Check if any locations are hidden.
          * @returns {boolean}
          */
-        areHidden: function () { return map.locations.cache.length > 0; },
+        anyHidden: function () { return map.locations._cache.length > 0; },
+
+        /**
+         * Creates all the location markers.
+         * @param {object[]} locations Collection of all the locations
+         * @param {object} options location marker options
+         * @param {string} popupHTML optional HTML string for marker popup
+         */
+        create: function(locations, options, popupHTML) {
+            const drawOptions = options ? options : map.options.markers.default;
+
+            let barOptions = {...drawOptions};
+            locations.forEach(loc => {
+
+                barOptions.title = loc.name.fi;
+                barOptions._description = loc.description;
+                barOptions._infoUrl = loc.info_url;
+
+                const marker = L.marker([loc.location.lat, loc.location.lon], barOptions)
+                    .addTo(map._instance);
+
+                if (popupHTML) {
+                    marker.bindPopup(popupHTML);
+                }
+
+                marker.locationId = loc.id;
+
+                marker.on('click', _ => setMarkerZoom(marker))
+                marker.on('click', async _ => {
+                    map.routes.clear();
+                    ui.toggleLocationPanel('down');
+
+                    const routes = await routesAPI.getRoutesToBarAsync(map.user.position, loc.location);
+                    if (routes) {
+                        ui.renderBarInfo(marker.options, routes, loc);
+                    } else {
+                        ui.renderError('no routes');
+                    }
+                })
+                this._markerPool.push(marker);
+            });
+        },
 
         /**
          * Clear all locations from the map.
          */
         clear: function() {
-            map.layers.locations.clearLayers();
+            map._layers.locations.clearLayers();
         },
 
         /**
@@ -216,14 +213,14 @@ export const map = {
          */
         onlyDisplayFocused: function(id) {
             // Cache all the markers currently displayed
-            for (const key in map.layers.locations._layers) {
-                if (map.layers.locations._layers.hasOwnProperty(key)) {
-                    map.locations.cache.push(map.layers.locations._layers[key])
+            for (const key in map._layers.locations._layers) {
+                if (map._layers.locations._layers.hasOwnProperty(key)) {
+                    map.locations._cache.push(map._layers.locations._layers[key])
                 }
             }
             map.locations.clear();
-            const focused = this.markerPool.find(l => l.locationId === id);
-            map.layers.locations.addLayer(focused);
+            const focused = this._markerPool.find(l => l.locationId === id);
+            map._layers.locations.addLayer(focused);
         },
 
         /**
@@ -232,88 +229,194 @@ export const map = {
          */
         popCacheToMap: function() {
             map.locations.clear();
-            map.locations.cache.forEach(m => {
-                map.layers.locations.addLayer(m);
+            map.locations._cache.forEach(m => {
+                map._layers.locations.addLayer(m);
             })
-            map.locations.cache.length = 0;
+            map.locations._cache.length = 0;
         }
     },
 
     /**
-    * Clears route layer from the map.
-    */
-    clearRoutes: function () {
-        this.layers.routes.clearLayers();
-        return this;
-    },
-
-    /**
-     * Sets the map view to specified position.
-     * @param {} position New map view position.
+     * Namespace to draw route polylines to map
      */
-    setView: function (position) {
-        this.instance.setView(position, 13)
-        return this;
-    },
+    routes: {
+        /**
+         * Clears the routes and route stop circles
+         * from the route layer.
+         */
+        clear: function() {
+            map._layers.routes.clearLayers();
+        },
+         
+        /**
+         * Draws route polyline to map. Adds route to route layer group.
+         * If draw options are not provided in parameters, polyline
+         * is drawn using default options.
+         * 
+         * @param {object} routeLeg route "leg" object that contains encoded polyline
+         * @param {object} drawOptions polyline style options
+         * @param {boolean} includeStops if true -> draws a circle
+         *      at the end of each route leg
+         */
+        draw: function(routeLeg, drawOptions, includeStops=false) {
+            const options = drawOptions ? drawOptions : map.options.routes.DEFAULT;
+            const route = L.polyline(polyline.decode(routeLeg.legGeometry.points), options);
+            map._layers.routes.addLayer(route);
 
-    /**
-     * Clears user's marker from the map.
-     */
-    clearUserLocationMarker: function () {
-        if (this.user.marker) {
-            this.instance.removeLayer(this.user.marker);
-            this.user.marker = null;
+            if (includeStops) {
+                map._layers.routes.addLayer(
+                    L.circle(
+                        [routeLeg.from.lat, routeLeg.from.lon],
+                        {radius: 20}
+                    )
+                );
+            }
         }
-        return this;
     },
 
     /**
-     * Refreshes user's marker to new position.
+     * Namespace to manipulate map view.
      */
-    refreshUserLocationMarker: function () {
-        this.clearUserLocationMarker();
-        this.user.marker = L.marker(this.user.position, this.markerOptions.user)
-        this.user.marker.addTo(this.instance);
-        return this;
-    },
+    view: {
+        /**
+         * Options object to specify how the view
+         * change animation plays out.
+         */
+        moveOptions: {
+            animate: true,
+            duration: 0.6,
+            easeLinearity: 0.25,
+            noMoveStart: true
+        },
 
-    createLocationHTML: function(location) {
-        return `<h3>${location.name.fi}</h3>`
+        /**
+         * Sets the map view to specified position with default
+         * zoom level of 13.
+         * @param {object} position object with lat/lon fields
+         * @param {number[]} position array with lat/lon values
+         * @param {object} options map move options object
+         * @param {number} zoomLevel defaults to 13
+         */
+        setTo: function(position, options, zoomLevel=13) {
+            const mOptions = options ? options : this.moveOptions;
+            map._instance.setView(position, zoomLevel, mOptions);
+        },
+
+        /**
+         * Focuses the map view to user's position
+         */
+        focus: function() {
+            map.view.setTo(
+                [map.user.position.lat, map.user.position.lon],
+                null,
+                16
+            );
+        },
+
+        /**
+         * Conditional zoom function. Zooms to specified position if
+         * user's current zoom level is lower than target zoom level.
+         * Otherwise only pans the view to specified position.
+         * 
+         * @param {number[]} position array containing lat and lon values
+         * @param {number} zoomTreshold if user already is zoomed beyound this
+         *  level, no zoom is executed.
+         * @param {number} zoomLevel target zoom level
+         * @param {object} options move view options
+         */
+        zoomTo: function(position, zoomTreshold, zoomLevel, options=null) {
+            if (map._instance.getZoom() >= zoomTreshold) {
+                this.setTo(position, options, map._instance.getZoom());
+            } else {
+                this.setTo(position, options, zoomLevel)
+            }
+        }
     },
 
     /**
-     * Draws route polyline to map. Adds route to route layer group.
-     * If draw options are not provided in parameters, polyline
-     * is drawn using default options.
-     * 
-     * @param {string} points encoded google polyline string
-     * @param {object} drawOptions polyline style options
-     * 
+     * Namespace for leaflet map option
+     * templates.
      */
-    drawRoute: function (points, drawOptions) {
-        const options = drawOptions ? drawOptions : this.routeDrawOptions.DEFAULT;
-        const route = L.polyline(polyline.decode(points), options);
-        route.addTo(this.instance);
-        this.layers.routes.addLayer(route);
-        return this;
+    options: {
+
+        /**
+         * Options for predefined markers
+         */
+        markers: {
+            default: {
+                title : 'title here',
+                alt: 'alt comes here',
+                opacity: 0.8,
+                riseOnHover: true
+            },
+            bar: {
+                icon : L.icon({
+                    iconUrl: './icons/beer-icon.png',
+                    iconSize: [40, 45],
+                    iconAnchor: [20, 40],
+                    popupAnchor:[0, -40]
+                }),
+                title : 'Kalja rafla',
+                alt: 'alt comes here',
+                opacity: 0.8,
+                riseOnHover: true
+            },
+            user: {
+                title : 'Sinä',
+                alt: 'alt comes here',
+                riseOnHover: true
+            }
+        },
+
+        /**
+         * Polyline style options. Use these
+         * when you wish to draw new polylines with
+         * pre-defined styles to map.
+         */
+        routes: {
+            'DEFAULT': {
+                color: '#5eb5a7',
+                smoothFactor: 1,
+                noClip: false,
+                weight: 3,
+            },
+            'BUS': {
+                color: '#1c8bc9',
+                noClip: true,
+                weight: 3
+            },
+            'RAIL': {
+                color: '#b8659d',
+                noClip: true,
+                weight: 3
+            },
+            'SUBWAY': {
+                color: '#f75701',
+                noClip: true,
+                weight: 3
+            },
+            'TRAM': {
+                color: '#196343',
+                noClip: true,
+                weight: 3,
+            },
+            'WALK': {
+                color: '#5eb5a7',
+                noClip: true,
+                weight: 5,
+                dashArray: '1, 6',
+            },
+            'FERRY': {
+                color: '#196343',
+                noClip: true,
+                weight: 4,
+            }
+        },
     },
-    /**
-    * Draws circles for the stops on the map
-    *
-    * @param {Array} latitude and longitude as an array 
-    */
-    drawRouteStop: function(latLng) {
-
-        const circle = L.circle(
-            latLng, {radius: 20}
-        ).addTo(
-        this.instance
-        );
-        this.layers.routes.addLayer(circle);
-
-        return this;
-    }
 }
+
+
+
 
 /**
 * Calculates the distance in meters between two coordinate points
@@ -339,17 +442,11 @@ export function calculateDistance(lat1, long1, lat2, long2) {
 };
 
 function setMarkerZoom(marker) {
-    if (map.instance.getZoom() >= 13) {
-        map.instance.panTo(marker.getLatLng(), map.instance.moveViewOptions); // No zoom
+    if (map._instance.getZoom() >= 13) {
+        map._instance.panTo(marker.getLatLng(), map._instance.moveViewOptions); // No zoom
     } else {
-        map.instance.setView(marker.getLatLng(), 13,
-        map.instance.moveViewOptions);
-    }
-    if (map.user.marker) {
-        map.user.marker.setOpacity(0.8);
-        map.user.marker.setZIndexOffset(0);
+        map.view.setTo(marker.getLatLng());
     }
     marker.setOpacity(1);
     marker.setZIndexOffset(100);
 }
-

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -144,7 +144,7 @@ export const map = {
          * objects. When the objects are first
          * created, they are to be stored here.
          */
-        _markerPool: [],
+        _markerPool: {},
 
         /**
          * Cache for temporarely cleared locations.
@@ -194,7 +194,7 @@ export const map = {
                         ui.renderError('no routes');
                     }
                 })
-                this._markerPool.push(marker);
+                this._markerPool[marker.locationId] = marker;
             });
         },
 
@@ -209,7 +209,7 @@ export const map = {
          * Removes all other markers than the marker with
          * provided id from the map. Removed markers are cached for
          * future use.
-         * @param {number} id marker id that remains visible.
+         * @param {string} id marker id that remains visible.
          */
         onlyDisplayFocused: function(id) {
             // Cache all the markers currently displayed
@@ -219,8 +219,10 @@ export const map = {
                 }
             }
             map.locations.clear();
-            const focused = this._markerPool.find(l => l.locationId === id);
-            map._layers.locations.addLayer(focused);
+            if (this._markerPool.hasOwnProperty(id)) {
+                const focused = this._markerPool[id];
+                map._layers.locations.addLayer(focused);
+            }
         },
 
         /**

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -55,7 +55,7 @@ export const ui = {
         const closeRouteBtn = document.querySelector('#close-route-btn');
 
         closeRouteBtn.addEventListener('click', _ => {
-            if (map.locations.areHidden()) {
+            if (map.locations.anyHidden()) {
                 map.locations.popCacheToMap();
             }
 
@@ -67,15 +67,15 @@ export const ui = {
             document.querySelectorAll('.active-route').forEach(x => {
                 x.classList.remove('active-route');
             });
-            map.clearRoutes();
+            map.routes.clear();
         });
 
         routePanelBtn.addEventListener('click', _ => {
-            if (map.locations.areHidden()) {
+            if (map.locations.anyHidden()) {
                 map.locations.popCacheToMap();
             }
             routePanel.classList.toggle('routes-down');
-            map.clearRoutes();
+            map.routes.clear();
         });
 
         // locate button
@@ -195,7 +195,7 @@ export const ui = {
             }
         }
 
-        map.clearRoutes();
+        map.routes.clear();
         document.querySelectorAll(".route-leg").forEach(x => {
             x.remove();
         });
@@ -255,22 +255,15 @@ export const ui = {
                 ${routeStringParts.join(" - ")}
             </span>`;
             routeInstructionsList.appendChild(legItem);
-            map.drawRoute(leg.legGeometry.points, map.routeDrawOptions[leg.mode]);
+            
+            map.routes.draw(leg, map.options.routes[leg.mode], true);
 
-            map.drawRouteStop([leg.from.lat, leg.from.lon]);
-
-            legItem.addEventListener('click', evt => {this.zoomOnLeg(leg);});
-
+            legItem.addEventListener('click', _ => {
+                map.view.zoomTo([leg.from.lat, leg.from.lon], 16, 17);
+            });
         });
     },
-    zoomOnLeg(leg) {
-        if (map.instance.getZoom() >= 20) {
-            map.instance.panTo([leg.from.lat, leg.from.lon], map.instance.moveViewOptions); // No zoom
-        } else {
-            map.instance.setView([leg.from.lat, leg.from.lon], 20,
-            map.instance.moveViewOptions);
-        }
-    },
+    
     renderError: function(err) {
         console.error(err);
     },


### PR DESCRIPTION
## Refactored map methods to separate namespaces
### example:
#### old
```
map.drawRoute();

map.focus();

map.createLocations();
```
#### new
```
map.routes.draw();

map.view.focus();

map.locations.create();
```

## Markerpool object is now dictionary (was array)
#### This is beacause finding markers by id was inefficient when pool was an array.
#### Now, location id's are keys, markers are values
#### old
```
filteredBarIds.forEach(id => {
    const len = map.locations.markerPool.length;
     for (let i = 0; i < len; i++) {	
          const m = map.locations.markerPool[i];	
          if (m.locationId === id) {	
              map.layers.locations.addLayer(m);	
          }	
      }	
});
```
#### new
```
filteredBarIds.forEach(id => {
    map._layers.locations.addLayer(map.locations._markerPool[id])
});
```

## And bunch of new functions
#### for example:
```
map.user.move();

map.user.hide();

map.user.visible();
```
